### PR TITLE
Fix windows build

### DIFF
--- a/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling.cpp
+++ b/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling.cpp
@@ -23,11 +23,11 @@ std::vector<at::Tensor> grid_subsampling(
   );
   std::vector<PointXYZ> vec_s_points;
 
-  std::vector<long> vec_lengths = std::vector<long>(
-    lengths.data_ptr<long>(),
-    lengths.data_ptr<long>() + batch_size
+  std::vector<int64_t> vec_lengths = std::vector<int64_t>(
+    lengths.data_ptr<int64_t>(),
+    lengths.data_ptr<int64_t>() + batch_size
   );
-  std::vector<long> vec_s_lengths;
+  std::vector<int64_t> vec_s_lengths;
 
   grid_subsampling_cpu(
     vec_points,
@@ -39,11 +39,11 @@ std::vector<at::Tensor> grid_subsampling(
 
   std::size_t total_s_points = vec_s_points.size();
   at::Tensor s_points = torch::zeros(
-    {total_s_points, 3},
+    {static_cast<int64_t>(total_s_points), 3},
     at::device(points.device()).dtype(at::ScalarType::Float)
   );
   at::Tensor s_lengths = torch::zeros(
-    {batch_size},
+    {static_cast<int64_t>(batch_size)},
     at::device(lengths.device()).dtype(at::ScalarType::Long)
   );
 
@@ -53,9 +53,9 @@ std::vector<at::Tensor> grid_subsampling(
     sizeof(float) * total_s_points * 3
   );
   std::memcpy(
-    s_lengths.data_ptr<long>(),
+    s_lengths.data_ptr<int64_t>(),
     vec_s_lengths.data(),
-    sizeof(long) * batch_size
+    sizeof(int64_t) * batch_size
   );
 
   return {s_points, s_lengths};

--- a/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling_cpu.cpp
+++ b/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling_cpu.cpp
@@ -50,8 +50,8 @@ void single_grid_subsampling_cpu(
 void grid_subsampling_cpu(
   std::vector<PointXYZ>& points,
   std::vector<PointXYZ>& s_points,
-  std::vector<long>& lengths,
-  std::vector<long>& s_lengths,
+  std::vector<int64_t>& lengths,
+  std::vector<int64_t>& s_lengths,
   float voxel_size
 ) {
   std::size_t start_index = 0;

--- a/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling_cpu.h
+++ b/geotransformer/extensions/cpu/grid_subsampling/grid_subsampling_cpu.h
@@ -29,8 +29,8 @@ void single_grid_subsampling_cpu(
 void grid_subsampling_cpu(
   std::vector<PointXYZ>& o_points,
   std::vector<PointXYZ>& s_points,
-  std::vector<long>& o_lengths,
-  std::vector<long>& s_lengths,
+  std::vector<int64_t>& o_lengths,
+  std::vector<int64_t>& s_lengths,
   float voxel_size
 );
 

--- a/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors.cpp
+++ b/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors.cpp
@@ -34,13 +34,13 @@ at::Tensor radius_neighbors(
     reinterpret_cast<PointXYZ*>(s_points.data_ptr<float>()),
     reinterpret_cast<PointXYZ*>(s_points.data_ptr<float>()) + total_s_points
   );
-  std::vector<long> vec_q_lengths = std::vector<long>(
-    q_lengths.data_ptr<long>(), q_lengths.data_ptr<long>() + batch_size
+  std::vector<int64_t> vec_q_lengths = std::vector<int64_t>(
+    q_lengths.data_ptr<int64_t>(), q_lengths.data_ptr<int64_t>() + batch_size
   );
-  std::vector<long> vec_s_lengths = std::vector<long>(
-    s_lengths.data_ptr<long>(), s_lengths.data_ptr<long>() + batch_size
+  std::vector<int64_t> vec_s_lengths = std::vector<int64_t>(
+    s_lengths.data_ptr<int64_t>(), s_lengths.data_ptr<int64_t>() + batch_size
   );
-  std::vector<long> vec_neighbor_indices;
+  std::vector<int64_t> vec_neighbor_indices;
 
   radius_neighbors_cpu(
     vec_q_points,
@@ -54,14 +54,14 @@ at::Tensor radius_neighbors(
   std::size_t max_neighbors = vec_neighbor_indices.size() / total_q_points;
 
   at::Tensor neighbor_indices = torch::zeros(
-    {total_q_points, max_neighbors},
+    {static_cast<int64_t>(total_q_points), static_cast<int64_t>(max_neighbors)},
     at::device(q_points.device()).dtype(at::ScalarType::Long)
   );
 
   std::memcpy(
-    neighbor_indices.data_ptr<long>(),
+    neighbor_indices.data_ptr<int64_t>(),
     vec_neighbor_indices.data(),
-    sizeof(long) * total_q_points * max_neighbors
+    sizeof(int64_t) * total_q_points * max_neighbors
   );
 
   return neighbor_indices;

--- a/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors_cpu.cpp
+++ b/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors_cpu.cpp
@@ -3,9 +3,9 @@
 void radius_neighbors_cpu(
   std::vector<PointXYZ>& q_points,
   std::vector<PointXYZ>& s_points,
-  std::vector<long>& q_lengths,
-  std::vector<long>& s_lengths,
-  std::vector<long>& neighbor_indices,
+  std::vector<int64_t>& q_lengths,
+  std::vector<int64_t>& s_lengths,
+  std::vector<int64_t>& neighbor_indices,
   float radius
 ) {
   std::size_t i0 = 0;

--- a/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors_cpu.h
+++ b/geotransformer/extensions/cpu/radius_neighbors/radius_neighbors_cpu.h
@@ -9,8 +9,8 @@ typedef nanoflann::KDTreeSingleIndexAdaptor<
 void radius_neighbors_cpu(
   std::vector<PointXYZ>& q_points,
   std::vector<PointXYZ>& s_points,
-  std::vector<long>& q_lengths,
-  std::vector<long>& s_lengths,
-  std::vector<long>& neighbor_indices,
+  std::vector<int64_t>& q_lengths,
+  std::vector<int64_t>& s_lengths,
+  std::vector<int64_t>& neighbor_indices,
   float radius
 );


### PR DESCRIPTION

The size of the long type can vary across different systems. For instance, on Linux, it is 64-bit, while on Windows, it is 32-bit 

However, int64_t is a fixed-size data type that is consistent across all systems. It is a 64-bit integer type that can be used to store large numbers 

https://stackoverflow.com/questions/43444789/why-do-datatypes-have-different-sizes-on-different-architectures-i-e-a-c-in